### PR TITLE
Use the lock repository for fallback metadata only

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -76,7 +76,7 @@ final class Validator
     /**
      * @param array<mixed> $composerLock
      */
-    private function buildComposerLockRepository(array $composerLock, bool $canonical = true): LockArrayRepository
+    private function buildComposerLockRepository(array $composerLock, bool $canonical = true): LockArrayRepository|FilterRepository
     {
         if (
             !isset($composerLock['packages'], $composerLock['packages-dev'])

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -54,7 +54,7 @@ final class Validator
             $composerLockRepository = $this->buildComposerLockRepository($composerLock);
 
             // Use the pool because this handles all the replaces and provides as well
-            $pool = $this->createPool($composerLockRepository, $existingComposerLock ? $this->buildComposerLockRepository($existingComposerLock) : null);
+            $pool = $this->createPool($composerLockRepository);
 
             // 2nd step: validate if there is a package present, that is not required by the root composer.json
             // 3rd step: validate if no package has been removed from the composer.lock
@@ -63,7 +63,7 @@ final class Validator
             // 4th step: validate the metadata of all provided packages in the composer.lock.
             // In case of the full update, all the packages have to be compared against the repository data
             foreach ($composerLockRepository->getPackages() as $package) {
-                $this->validatePackageMetadataAgainstRepositories($package, $pool, null !== $existingComposerLock);
+                $this->validatePackageMetadataAgainstRepositories($package, $pool, $existingComposerLock ? $this->buildComposerLockRepository($existingComposerLock) : null);
             }
         } catch (ValidationException $exception) {
             throw $exception;
@@ -141,7 +141,7 @@ final class Validator
      * @throws ValidationException
      * @throws \Throwable
      */
-    private function validatePackageMetadataAgainstRepositories(PackageInterface $package, Pool $pool, bool $addHintAboutLocalComposerLockOnFailure): void
+    private function validatePackageMetadataAgainstRepositories(PackageInterface $package, Pool $pool, LockArrayRepository|null $existingLockRepository = null): void
     {
         $providedPackageArray = $this->dumpPackage($package);
 
@@ -153,7 +153,15 @@ final class Validator
             }
         }
 
-        throw ValidationException::becauseOfInvalidMetadataForPackage($package->getName(), $package->getVersion(), $providedPackageArray, $validPackageArray ?? [], $addHintAboutLocalComposerLockOnFailure);
+        if ($package = $existingLockRepository?->findPackage($package->getName(), new Constraint('=', $package->getVersion()))) {
+            $validPackageArray = $this->dumpPackage($validPackage);
+
+            if ($providedPackageArray === $validPackageArray) {
+                return; // Valid!
+            }
+        }
+
+        throw ValidationException::becauseOfInvalidMetadataForPackage($package->getName(), $package->getVersion(), $providedPackageArray, $validPackageArray ?? [], null !== $existingLockRepository);
     }
 
     /**
@@ -181,7 +189,7 @@ final class Validator
         return $dump;
     }
 
-    private function createPool(LockArrayRepository $composerLockRepo, LockArrayRepository|null $existingComposerLockRepo = null): Pool
+    private function createPool(LockArrayRepository $composerLockRepo): Pool
     {
         $rootPackage = $this->getRootPackage();
 
@@ -191,11 +199,6 @@ final class Validator
             $rootPackage->getAliases(),
             $rootPackage->getReferences(),
         );
-
-        // Add the existing composer lock repo as repository for valid packages too, in case that was passed
-        if ($existingComposerLockRepo) {
-            $repoSet->addRepository($existingComposerLockRepo);
-        }
 
         $repoSet->addRepository(new RootPackageRepository($rootPackage));
 

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -153,7 +153,7 @@ final class Validator
             }
         }
 
-        if ($package = $existingLockRepository?->findPackage($package->getName(), new Constraint('=', $package->getVersion()))) {
+        if ($validPackage = $existingLockRepository?->findPackage($package->getName(), new Constraint('=', $package->getVersion()))) {
             $validPackageArray = $this->dumpPackage($validPackage);
 
             if ($providedPackageArray === $validPackageArray) {

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -153,7 +153,7 @@ final class Validator
             }
         }
 
-        if ($validPackage = $existingLockRepository?->findPackage($package->getName(), new Constraint('=', $package->getVersion()))) {
+        if ($package = $existingLockRepository?->findPackage($package->getName(), new Constraint('=', $package->getVersion()))) {
             $validPackageArray = $this->dumpPackage($validPackage);
 
             if ($providedPackageArray === $validPackageArray) {


### PR DESCRIPTION
The existing `composer.lock` is currently added as first repository to the pool/reposet. If a package name is found in the lock repo, no other repository is asked, which means only the version provided by the lock file would be found. This could be fixed by moving the repository to the last in the chain – but then again, it would never be asked for something.

Additionally, we only want the lock repository to provide metadata, we do not want it to provide a list of "known" packages, they should still be available from repository imho.